### PR TITLE
Cloned parts are now drawn with slanted corners

### DIFF
--- a/los/Composer/ComposerCanvas.cpp
+++ b/los/Composer/ComposerCanvas.cpp
@@ -1814,9 +1814,6 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
 
     QRect r = item->bbox();
 
-    //Qrect vv = r::getCoords(int * x1, int * y1, int * x2, int * y2) const;
-    //QRect::getCoords(int * x1, int * y1, int * x2, int * y2) const;
-
     //printf("ComposerCanvas::drawItem %s evRefs:%d pTick:%d pLen:%d\nbb.x:%d bb.y:%d bb.w:%d bb.h:%d\n"
     //       "rect.x:%d rect.y:%d rect.w:%d rect.h:%d\nr.x:%d r.y:%d r.w:%d r.h:%d\n",
     //  part->name().toLatin1().constData(), part->events()->arefCount(), pTick, part->lenTick(),

--- a/los/Composer/ComposerCanvas.cpp
+++ b/los/Composer/ComposerCanvas.cpp
@@ -1849,33 +1849,48 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
         if (mp)
             p.setPen(partWaveColor);
     }
-    // Draw clones with slanted corners
-    if ((part->events()->arefCount() > 1)) // True if part is a clone
+    
+    // Draw clones with slanted corners. 
+    
+    if ((part->events()->arefCount() > 1)) // Part is a clone, so draw a polygon
     {
-        // VIKTOR - ALMOST THERE!
-        // doing math on x() doesn't work because it moves with the zoom level!
-        // y() stays the same though since you can't zoom horizontally. Hmm...
+        int slant;
+        if (xmag < -500)
+        {
+            slant = 4;
+        }
+        else
+        {
+            slant = 7;
+        }
 
-        // Idea: use the tick (probably won't work for same reason)
+        // TODO: Don't  draw a slant that extends beyond the width of the actual part
+        // while (slant >= item->width()) // (this doesn't quite work, math is off)
+        // {
+        //     slant = slant - 1;
+        // }
 
-        // Idea: do geometry at a 45 degree angle from
+        // Random debugging stuff to get my bearings
+        // printf("Item Width: ");
+        // printf("%g\n", item->width());
+        // printf("H-Zoom Level (xmag): ");
+        // printf("%g\n", xmag);
+        // printf(" ")
 
-        QPolygon polygon;
-        polygon << QPoint(item->x(), item->y() +6)
-                << QPoint(item->x() - 6 * xmag, item->y())      // Keeps the angled corner consistent regardless of zoom level
+        QPolygon polygon;            
+        polygon << QPoint(item->x(), item->y() + slant)
+                << QPoint(item->x() - slant * xmag, item->y())      
                 << QPoint(item->x() + item->width(), item->y())
-                << QPoint(item->x() + item->width(), item->y() + item->height() - 6)
-                << QPoint(item->x() + item->width() + 6 * xmag, item->y() + item->height())
+                << QPoint(item->x() + item->width(), item->y() + item->height() - slant)
+                << QPoint(item->x() + item->width() + slant * xmag, item->y() + item->height())
                 << QPoint(item->x(), item->y() + item->height());
-
-//        QPolygon polygon;
-//        p.drawPolygon(QPoint * points, 5);
         p.drawPolygon(polygon, Qt::OddEvenFill);
     }
     else // Part is not a clone, so draw a normal rectangle
     {
         p.drawRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1));
     }
+    
     if (part->mute() || part->track()->mute())
     {
         QBrush muteBrush;

--- a/los/Composer/ComposerCanvas.cpp
+++ b/los/Composer/ComposerCanvas.cpp
@@ -1861,10 +1861,11 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
         // Idea: do geometry at a 45 degree angle from
 
         QPolygon polygon;
-        polygon << QPoint(item->x(), item->y() +8)
-                << QPoint(item->x() + 80, item->y())
+        polygon << QPoint(item->x(), item->y() +6)
+                << QPoint(item->x() - 6 * xmag, item->y())      // Keeps the angled corner consistent regardless of zoom level
                 << QPoint(item->x() + item->width(), item->y())
-                << QPoint(item->x() + item->width(), item->y() + item->height())
+                << QPoint(item->x() + item->width(), item->y() + item->height() - 6)
+                << QPoint(item->x() + item->width() + 6 * xmag, item->y() + item->height())
                 << QPoint(item->x(), item->y() + item->height());
 
 //        QPolygon polygon;

--- a/los/Composer/ComposerCanvas.cpp
+++ b/los/Composer/ComposerCanvas.cpp
@@ -1814,6 +1814,9 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
 
     QRect r = item->bbox();
 
+    //Qrect vv = r::getCoords(int * x1, int * y1, int * x2, int * y2) const;
+    //QRect::getCoords(int * x1, int * y1, int * x2, int * y2) const;
+
     //printf("ComposerCanvas::drawItem %s evRefs:%d pTick:%d pLen:%d\nbb.x:%d bb.y:%d bb.w:%d bb.h:%d\n"
     //       "rect.x:%d rect.y:%d rect.w:%d rect.h:%d\nr.x:%d r.y:%d r.w:%d r.h:%d\n",
     //  part->name().toLatin1().constData(), part->events()->arefCount(), pTick, part->lenTick(),
@@ -1846,19 +1849,29 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
         if (mp)
             p.setPen(partWaveColor);
     }
-    // Make clones look unique
-    if ((part->events()->arefCount() > 1))
+    // Draw clones with slanted corners
+    if ((part->events()->arefCount() > 1)) // True if part is a clone
     {
-        // rounded rectangles look like crap because their radius changes based on the size of the rectangle
-        //p.drawRoundedRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1), 0, 25 );
-        //QPointF polygon(QPointF(r.x(), r.y()-10),QPointF(r.x()+10, r.y()), QPointF(r.x()+r.width()), QPointF(r.mp ? r.height()-2 : r.height()-1), 5 );
+        // VIKTOR - ALMOST THERE!
+        // doing math on x() doesn't work because it moves with the zoom level!
+        // y() stays the same though since you can't zoom horizontally. Hmm...
+
+        // Idea: use the tick (probably won't work for same reason)
+
+        // Idea: do geometry at a 45 degree angle from
+
         QPolygon polygon;
-        polygon << QPoint(r.x(), r.y()-10) << QPoint(r.x()+10, r.y()) << QPoint(r.x()+r.width(), r.height()-2) << QPoint(r.x(), r.y()-r.height()-2);
+        polygon << QPoint(item->x(), item->y() +8)
+                << QPoint(item->x() + 80, item->y())
+                << QPoint(item->x() + item->width(), item->y())
+                << QPoint(item->x() + item->width(), item->y() + item->height())
+                << QPoint(item->x(), item->y() + item->height());
+
 //        QPolygon polygon;
 //        p.drawPolygon(QPoint * points, 5);
         p.drawPolygon(polygon, Qt::OddEvenFill);
     }
-    else
+    else // Part is not a clone, so draw a normal rectangle
     {
         p.drawRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1));
     }

--- a/los/Composer/ComposerCanvas.cpp
+++ b/los/Composer/ComposerCanvas.cpp
@@ -1846,7 +1846,22 @@ void ComposerCanvas::drawItem(QPainter& p, const CItem* item, const QRect& rect)
         if (mp)
             p.setPen(partWaveColor);
     }
-    p.drawRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1));
+    // Make clones look unique
+    if ((part->events()->arefCount() > 1))
+    {
+        // rounded rectangles look like crap because their radius changes based on the size of the rectangle
+        //p.drawRoundedRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1), 0, 25 );
+        //QPointF polygon(QPointF(r.x(), r.y()-10),QPointF(r.x()+10, r.y()), QPointF(r.x()+r.width()), QPointF(r.mp ? r.height()-2 : r.height()-1), 5 );
+        QPolygon polygon;
+        polygon << QPoint(r.x(), r.y()-10) << QPoint(r.x()+10, r.y()) << QPoint(r.x()+r.width(), r.height()-2) << QPoint(r.x(), r.y()-r.height()-2);
+//        QPolygon polygon;
+//        p.drawPolygon(QPoint * points, 5);
+        p.drawPolygon(polygon, Qt::OddEvenFill);
+    }
+    else
+    {
+        p.drawRect(QRect(r.x(), r.y(), r.width(), mp ? r.height()-2 : r.height()-1));
+    }
     if (part->mute() || part->track()->mute())
     {
         QBrush muteBrush;


### PR DESCRIPTION
Took a bit of digging and some trial and error, but I got it!
And man, this is a game changer for pattern based compositions in LOS 

Here's what it looks like:
![2015-08-25-215036_1280x800_scrot](https://cloud.githubusercontent.com/assets/3234333/9490202/33042256-4b9b-11e5-99d0-bf095692c45e.png)

I didn't notice any difference in rendering time, and the slants stay consistent regardless of zoom level
Fixes https://github.com/falkTX/los/issues/2