### PR TITLE
Fixed Marker View table headers

### DIFF
--- a/los/marker/markerview.cpp
+++ b/los/marker/markerview.cpp
@@ -169,7 +169,7 @@ MarkerView::MarkerView(QWidget* parent)
 
     QStringList columnnames;
     columnnames << tr("Bar:Beat:Tick")
-            << tr("Hr:Mn:Sc:Fr:Sf")
+//            << tr("Hr:Mn:Sc:Fr:Sf")
             << tr("Lock")
             << tr("Text");
 


### PR DESCRIPTION
Now only shows Bar:Beat:Tick, Lock, Text, so everything lines up.
![image](https://cloud.githubusercontent.com/assets/3234333/9537543/83ba21c4-4cee-11e5-910b-6a24670d5166.png)

I wasn't sure if you intended to replace the SMPTE timestamp you took out with something else that provides the Hh:Mm:Ss at some point, so I just commented the extra header out. 
(I personally like it better without it, more clean)

Fixes #21