### PR TITLE
Renaming a cloned part now renames all of its clones, + compile fixes

### DIFF
--- a/compile_los.sh
+++ b/compile_los.sh
@@ -7,4 +7,4 @@ else
 	mkdir build-debug
 fi
 cd build-debug
-cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j 4 && echo "Build was OK, now enter the 'build-debug' dir and run 'make install' as root"
+cmake -DCMAKE_BUILD_TYPE=Debug .. && make && echo "Build was OK, now enter the 'build-debug' dir and run 'make install' as root"


### PR DESCRIPTION
This partially addresses https://github.com/falkTX/los/issues/18
When a cloned part is renamed, all of it's clones are now traversed and subsequently renamed also. 
(I'm working on getting colors to behave the same way but am not quite there yet)

Also, I removed the -j4 flag from the build script compile_los.sh, as this seemed to make the build process get ahead of itself and break. (if the old script was ran multiple times, it would eventually build, but with -j4 removed it now successfully builds the first time)
